### PR TITLE
Use the existing Attacker structure as defined by the MAL Toolbox

### DIFF
--- a/attack_simulation.py
+++ b/attack_simulation.py
@@ -329,7 +329,7 @@ class AttackSimulation:
         cost_dictionary = {}
         for attackgraph_node in self.attackgraph_instance.nodes:
             ttc = attackgraph_node.ttc
-            if ttc == None:
+            if ttc == None or ttc == {}:
                 cost_dictionary[attackgraph_node.id] = 0
             elif ttc != None:
                 cost_dictionary[attackgraph_node.id] = help_functions.cost_from_ttc(ttc, 100)

--- a/attack_simulation.py
+++ b/attack_simulation.py
@@ -67,21 +67,6 @@ class AttackSimulation:
         print(f"{constants.RED}Attacker Horizon{constants.STANDARD}")
         help_functions.print_dictionary(attack_surface_dict)
 
-    def add_children_to_horizon(self, node):
-        """
-        Add the horizon nodes to the set of visited nodes.
-
-        This method iterates over the children of the given node, adding each child's
-        ID to the set of visited nodes (self.visited) if it is not already present in the set.
-
-        Parameters:
-        - node: The AttackGraphNode whose children are to be added to the horizon.
-
-        """
-        for child in node.children:
-            if child.id not in self.visited:
-                self.horizon.add(child.id)
-
     def build_attack_surface_dict(self):
         """
         Build a dictionary with an integer as keys and Node ID:s as values.

--- a/main.py
+++ b/main.py
@@ -33,7 +33,6 @@ def main():
     # Select one attacker for the simulation.
     # Note: it is possible to add a custom attacker with the model module and thereafter you can run attackgraph.attach_attackers.
     asset = model.get_asset_by_id(0)
-    model.attackers[0].entry_points.append((asset, ["attemptFullAccessFromSupplyChainCompromise"]))
     attackgraph.attach_attackers(model)
     attacker = attackgraph.attackers[0]
     attacker_entry_point = attacker.node.id


### PR DESCRIPTION
- Remove a few hardcoded values, we should extract the information from the model as much as possible. And models can include attacker entry points.
- Use newly introduced `compromise` function for Attackers. This function was added to reduce the likelihood that things are not set correctly. When the attacker compromises a node it needs to be added to the list of reached steps, but also the attacker needs to be added to the compromised by list of the node as well. The newly added `compromise` does both of these and checks to see if the node was already listed as compromised to avoid duplication.
- As a result of the previous item all functions that manipulate the reach/horizon of the attacker manually should be avoided and one was removed.
- Set the cost to 0 when converting from an empty dictionary value for TTCs. Not sure why we have both None and {} values, but we do.